### PR TITLE
Import "takeEvery" from "redux-saga/effects"

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "eslint-plugin-babel": "^3.0.0",
     "flux-standard-action": "^0.6.0",
     "mocha": "^2.3.4",
-    "redux-saga": "^0.10.5",
+    "redux-saga": "^0.14.8",
     "rimraf": "^2.5.4"
   },
   "peerDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
-import { takeEvery } from 'redux-saga';
-import { take, race, put, call } from 'redux-saga/effects';
+import { take, race, put, call, takeEvery } from 'redux-saga/effects';
 
 export const PROMISE_ACTION = '@@redux-saga-actions/PROMISE';
 
@@ -77,7 +76,7 @@ export function* handleActionSaga({ payload }) {
 }
 
 export function* actionsWatcherSaga() {
-  yield call(takeEvery, PROMISE_ACTION, handleActionSaga);
+  yield takeEvery(PROMISE_ACTION, handleActionSaga);
 }
 
 export default actionsWatcherSaga;


### PR DESCRIPTION
This change fixes the next warning:

> import takeEvery from 'redux-saga' has been deprecated in favor of import takeEvery from 'redux-saga/effects'.
The latter will not work with yield*, as helper effects are wrapped automatically for you in fork effect.
Therefore yield takeEvery will return task descriptor to your saga and execute next lines of code